### PR TITLE
Add option to skip verification or skip when gpg is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ asdf plugin-add waypoint https://github.com/asdf-community/asdf-hashicorp.git
 Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to
 install & manage versions.
 
+### Environment Variable Options
+- ASDF_HASHICORP_SKIP_VERIFY: skip verifying checksums and signatures
+
 ## License
 
 Licensed under the

--- a/bin/install
+++ b/bin/install
@@ -23,6 +23,7 @@ TMP_DOWNLOAD_DIR="$(mktemp -d -t "asdf_${toolname}_XXXXXX")"
 readonly TMP_DOWNLOAD_DIR
 trap 'rm -rf "${TMP_DOWNLOAD_DIR?}"' EXIT
 
+SKIP_VERIFY=${ASDF_HASHICORP_SKIP_VERIFY:-"false"}
 gnupg() {
   # This is one of the rare times when we want word splitting, so we can supply
   # a caller-specified number of arguments to this function to `gpg` as
@@ -76,8 +77,12 @@ install() {
 
   echo "Downloading ${toolname} version ${version} from ${download_url}"
   if curl -fs "${download_url}" -o "${download_path}"; then
-    echo "Verifying signatures and checksums"
-    verify "${version}" "${download_path}"
+    if command -v gpg >/dev/null 2>&1 && [ "${SKIP_VERIFY}" == "false" ]; then
+      echo "Verifying signatures and checksums"
+      verify "${version}" "${download_path}"
+    else
+      echo "Skipping verifying signatures and checksums either because gpg is not installed or explicitly skipped with ASDF_HASHICORP_SKIP_VERIFY"
+    fi
 
     echo "Cleaning ${toolname} previous binaries"
     rm -rf "${bin_install_path:?}/${toolname}"


### PR DESCRIPTION
Let verifying signatures and checksums be the default only when `gpg` is available. This also allows users to opt out of verification for older versions that might not be using the same gpg key.