### PR TITLE
always check the new Hashicorp key signatures

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -128,7 +128,7 @@ get_checksum_filename() {
 
 get_gpg_filename() {
   local -r version="$1"
-  echo "${toolname}_${version}_SHA256SUMS.sig"
+  echo "${toolname}_${version}_SHA256SUMS.72D7468F.sig"
 }
 
 get_download_url() {


### PR DESCRIPTION
For Hashicorp Vault packages, a `SHA256SUMS.sig` file is always present,
even for older version of Vault. However, for older Terraform versions,
this file contains an older signature. It seems that all releases of all
Hashicorp software support the new filename.

    $ asdf install terraform 0.14.10
    Downloading terraform version 0.14.10 from
    https://releases.hashicorp.com/terraform/0.14.10/terraform_0.14.10_linux_amd64.zip
    Verifying signatures and checksums
    gpg: keybox '/tmp/asdf_terraform_nMg8PU/pubring.kbx' created
    gpg: /tmp/asdf_terraform_nMg8PU/trustdb.gpg: trustdb created
    gpg: key 34365D9472D7468F: public key "HashiCorp Security
    (hashicorp.com/security) <security@hashicorp.com>" imported
    gpg: Total number processed: 1
    gpg:               imported: 1
    gpg: Signature made Thu 22 Apr 2021 01:16:33 PM EDT
    gpg:                using RSA key B0B441097685B676
    gpg: Good signature from "HashiCorp Security (hashicorp.com/security)
    <security@hashicorp.com>" [unknown]
    gpg: WARNING: This key is not certified with a trusted signature!
    gpg:          There is no indication that the signature belongs to the
    owner.
    Primary key fingerprint: C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7
    468F
         Subkey fingerprint: B36C BA91 A2C0 730C 435F  C280 B0B4 4109 7685
         B676
         terraform_0.14.10_linux_amd64.zip: OK
         Cleaning terraform previous binaries
         Creating terraform bin directory
         Extracting terraform archive

Fixes #26.

First and last Terraform contain this file:

https://releases.hashicorp.com/terraform/0.1.0/
https://releases.hashicorp.com/terraform/0.15.4/

First and last Consul contain it:

https://releases.hashicorp.com/consul/0.1.0/
https://releases.hashicorp.com/consul/1.10.0-beta2/

First and last last Vault contain it:

https://releases.hashicorp.com/vault/0.1.0/
https://releases.hashicorp.com/vault/1.7.0+ent.hsm/