### PR TITLE
Data dir can be in a different path

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 get_legacy_version() {
   local -r plugin_dir="$1"
   local -r tf_version_file="$2"
-  local -r terraform_dir="$ASDF_DIR/plugins/terraform"
+  local -r terraform_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/plugins/terraform"
 
   if [[ $plugin_dir =~ $terraform_dir ]]; then
     # Get version from .terraform-version file (used by tfenv)


### PR DESCRIPTION
The plugins are not always located under the `$ASDF_DIR/plugins` directory, this [data directory](https://github.com/asdf-vm/asdf/blob/v0.8.1/lib/utils.bash#L39-L49) can be changed or different depending on the installation method i.e. installing asdf through homebrew or manually overriding $ASDF_DATA_DIR.