### PR TITLE
Add support for `.packer-version` legacy file

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo ".terraform-version"
+echo ".terraform-version .packer-version"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -6,18 +6,15 @@ get_legacy_version() {
   local -r current_plugin="$1"
   local -r version_file="$2"
   local -r plugins_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/plugins"
+  local -r supported_plugins=(terraform packer)
 
-  local read_file=0
-  if [[ "${current_plugin}" =~ "${plugins_dir}/terraform" && "${version_file}" == *".terraform-version" ]]; then
-    read_file=1
-  elif [[ "${current_plugin}" =~ "${plugins_dir}/packer" && "${version_file}" == *".packer-version" ]]; then
-    read_file=1
-  fi
-
-  # Get version from .terraform-version/.packer-version file (used by tfenv/pkenv)
-  if [[ ${read_file} == 1 && -r "${version_file}" ]]; then
-    cat "${version_file}"
-  fi
+  # check if current plugin is supported and with a readable legacy file
+  for plugin in "${supported_plugins[@]}"; do
+    if [[ ${current_plugin} =~ ${plugins_dir}/${plugin} &&
+      ${version_file} == *".${plugin}-version" && -r ${version_file} ]]; then
+      cat "${version_file}"
+    fi
+  done
 }
 
 get_legacy_version "$0" "$1"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -3,15 +3,20 @@
 set -Eeuo pipefail
 
 get_legacy_version() {
-  local -r plugin_dir="$1"
-  local -r tf_version_file="$2"
-  local -r terraform_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/plugins/terraform"
+  local -r current_plugin="$1"
+  local -r version_file="$2"
+  local -r plugins_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/plugins"
 
-  if [[ $plugin_dir =~ $terraform_dir ]]; then
-    # Get version from .terraform-version file (used by tfenv)
-    if [[ -r ${tf_version_file} ]]; then
-      cat "${tf_version_file}"
-    fi
+  local read_file=0
+  if [[ "${current_plugin}" =~ "${plugins_dir}/terraform" && "${version_file}" == *".terraform-version" ]]; then
+    read_file=1
+  elif [[ "${current_plugin}" =~ "${plugins_dir}/packer" && "${version_file}" == *".packer-version" ]]; then
+    read_file=1
+  fi
+
+  # Get version from .terraform-version/.packer-version file (used by tfenv/pkenv)
+  if [[ ${read_file} == 1 && -r "${version_file}" ]]; then
+    cat "${version_file}"
   fi
 }
 


### PR DESCRIPTION
Used by [pkenv](https://github.com/iamhsa/pkenv) similar to tfenv but for packer. Reworked a bit the check so it can be more easily extended for other tools if the file naming doesn't change.