### PR TITLE
Add architecture specific tool overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ install & manage versions.
 ### Environment Variable Options
 - ASDF_HASHICORP_SKIP_VERIFY: skip verifying checksums and signatures
 - ASDF_HASHICORP_OVERWRITE_ARCH: force the plugin to use a specified processor architecture rather than the automatically detected value. Useful, for example, for allowing users on M1 Macs to install `amd64` binaries when there's no `arm64` binary available.
+- ASDF_HASHICORP_OVERWRITE_ARCH_<specific tool>: like the previous override, but for each specific tool, e.g. ASDF_HASHICORP_OVERWRITE_ARCH_TERRAFORM. Works with ASDF_HASHICORP_OVERWRITE_ARCH, and tool-specific overrides take precedence.
 
 ## License
 

--- a/bin/install
+++ b/bin/install
@@ -114,7 +114,12 @@ get_platform() {
 
 get_arch() {
   local -r machine="$(uname -m)"
-  OVERWRITE_ARCH=${ASDF_HASHICORP_OVERWRITE_ARCH:-"false"}
+  local -r upper_toolname="$(echo ${toolname} | tr '[:upper:]' '[:lower:]')"
+  local -r tool_specific_arch_override="ASDF_HASHICORP_OVERWRITE_ARCH_${upper_toolname}"
+
+  OVERWRITE_ARCH_TOOL=${!tool_specific_arch_override:-"false"}
+  OVERWRITE_ARCH=${OVERWRITE_ARCH_TOOL:-${ASDF_HASHICORP_OVERWRITE_ARCH}}
+
   if [[ $OVERWRITE_ARCH != "false" ]]; then
     echo "$OVERWRITE_ARCH"
   elif [[ $machine == "arm64" ]] || [[ $machine == "aarch64" ]]; then

--- a/bin/install
+++ b/bin/install
@@ -114,7 +114,7 @@ get_platform() {
 
 get_arch() {
   local -r machine="$(uname -m)"
-  local -r upper_toolname="$(echo ${toolname} | tr '[:upper:]' '[:lower:]')"
+  local -r upper_toolname=$(echo "${toolname}" | tr '[:upper:]' '[:lower:]')
   local -r tool_specific_arch_override="ASDF_HASHICORP_OVERWRITE_ARCH_${upper_toolname}"
 
   OVERWRITE_ARCH_TOOL=${!tool_specific_arch_override:-"false"}

--- a/bin/list-all
+++ b/bin/list-all
@@ -15,7 +15,7 @@ list_all() {
 
   for v in $(curl -s "https://releases.hashicorp.com/${toolname}/" |
     grep -o "${toolname}_[0-9]\+\.[0-9]\+\.[0-9]\+\(\(-\|+\)[a-z]\+[0-9]*\)*"); do
-    version="${v#${toolname}_}"
+    version="${v#"${toolname}"_}"
     if [[ -z ${versions} ]]; then
       versions="${version}"
     else


### PR DESCRIPTION
Also support ASDF_HASHICORP_OVERWRITE_ARCH_* (e.g. ASDF_HASHICORP_OVERWRITE_ARCH_TERRAFORM) for only overriding the architecture of a single HashiCorp tool.

Here's an example of this taking effect:
```
➜  ~ export ASDF_HASHICORP_OVERWRITE_ARCH="amd64"
➜  ~ asdf install terraform 1.0.11
Downloading terraform version 1.0.11 from https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_darwin_amd64.zip
Verifying signatures and checksums
gpg: keybox '/var/folders/63/gdk0jc_94xsfsb67br94yx440000gq/T/asdf_terraform_XXXXXX.OWH71w6t/pubring.kbx' created
gpg: /var/folders/63/gdk0jc_94xsfsb67br94yx440000gq/T/asdf_terraform_XXXXXX.OWH71w6t/trustdb.gpg: trustdb created
gpg: key 34365D9472D7468F: public key "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Wed Nov 10 16:41:21 2021 EST
gpg:                using RSA key B36CBA91A2C0730C435FC280B0B441097685B676
gpg: Good signature from "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F
     Subkey fingerprint: B36C BA91 A2C0 730C 435F  C280 B0B4 4109 7685 B676
terraform_1.0.11_darwin_amd64.zip: OK
Cleaning terraform previous binaries
Creating terraform bin directory
Extracting terraform archive
➜  ~ asdf uninstall terraform 1.0.11
➜  ~ terraform
zsh: command not found: terraform
➜  ~ export ASDF_HASHICORP_OVERWRITE_ARCH_TERRAFORM="arm64"
➜  ~ asdf install terraform 1.0.11
Downloading terraform version 1.0.11 from https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_darwin_arm64.zip
Verifying signatures and checksums
gpg: keybox '/var/folders/63/gdk0jc_94xsfsb67br94yx440000gq/T/asdf_terraform_XXXXXX.2j9CcSxY/pubring.kbx' created
gpg: /var/folders/63/gdk0jc_94xsfsb67br94yx440000gq/T/asdf_terraform_XXXXXX.2j9CcSxY/trustdb.gpg: trustdb created
gpg: key 34365D9472D7468F: public key "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Wed Nov 10 16:41:21 2021 EST
gpg:                using RSA key B36CBA91A2C0730C435FC280B0B441097685B676
gpg: Good signature from "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F
     Subkey fingerprint: B36C BA91 A2C0 730C 435F  C280 B0B4 4109 7685 B676
terraform_1.0.11_darwin_arm64.zip: OK
Cleaning terraform previous binaries
Creating terraform bin directory
Extracting terraform archive
```