### PR TITLE
fix lint check

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -15,7 +15,7 @@ list_all() {
 
   for v in $(curl -s "https://releases.hashicorp.com/${toolname}/" |
     grep -o "${toolname}_[0-9]\+\.[0-9]\+\.[0-9]\+\(\(-\|+\)[a-z]\+[0-9]*\)*"); do
-    version="${v#${toolname}_}"
+    version="${v#"${toolname}"_}"
     if [[ -z ${versions} ]]; then
       versions="${version}"
     else


### PR DESCRIPTION
The version of shellcheck we use in Github Actions was auto-upgraded recently and the new version comes with a fun new complaint about this existing line in `list-all`.