### PR TITLE
Support `required_version` with strict equality

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo ".terraform-version .packer-version"
+echo ".terraform-version .packer-version main.tf"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -12,6 +12,17 @@ get_legacy_version() {
       cat "${version_file}"
     fi
   done
+
+  if [[ "${version_file}" =~ "main.tf"  ]]; then
+    grep --no-filename \
+         --recursive \
+         --fixed-strings \
+         --exclude-dir .terraform \
+         required_version \
+         "$(dirname "${version_file}")" \
+      | sed -e 's/required_version\s*=\s*"=\(.*\)"/\1/' \
+      | tr -d ' '
+  fi
 }
 
 get_legacy_version "$1"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -3,18 +3,15 @@
 set -Eeuo pipefail
 
 get_legacy_version() {
-  local -r current_plugin="$1"
-  local -r version_file="$2"
-  local -r plugins_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/plugins"
+  local -r version_file="$1"
   local -r supported_plugins=(terraform packer)
 
   # check if current plugin is supported and with a readable legacy file
   for plugin in "${supported_plugins[@]}"; do
-    if [[ ${current_plugin} =~ ${plugins_dir}/${plugin} &&
-      ${version_file} == *".${plugin}-version" && -r ${version_file} ]]; then
+    if [[ ${version_file} == *".${plugin}-version" && -r ${version_file} ]]; then
       cat "${version_file}"
     fi
   done
 }
 
-get_legacy_version "$0" "$1"
+get_legacy_version "$1"

--- a/test/parse-legacy-file.bats
+++ b/test/parse-legacy-file.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+setup() {
+  ASDF_HASHICORP="$(dirname "$BATS_TEST_DIRNAME")"
+  PARSE_LEGACY_FILE="${ASDF_HASHICORP}/bin/parse-legacy-file"
+}
+
+@test "supports legacy terraform version 'required_version' with strict equality" {
+  local -r expected_terraform_version=0.13.7
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tf"
+  cat <<EOF > "${version_file}"
+terraform {
+  required_version = "= ${expected_terraform_version}"
+}
+EOF
+
+  local -r actual_terraform_version="$("${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ "${actual_terraform_version}" == "${expected_terraform_version}" ]]
+}
+
+@test "supports legacy file .terraform-version" {
+  local -r expected_terraform_version=0.13.7
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/.terraform-version"
+
+  echo "${expected_terraform_version}" > "${tmpdir}/.terraform-version"
+
+  local -r actual_terraform_version="$("${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ "${actual_terraform_version}" == "${expected_terraform_version}" ]]
+}


### PR DESCRIPTION
Hi! I'm interested in using this plugin to manage my terraform versions. I think that this plugin might benefit from support for the terraform `required_version` setting. 
I can anticipate some objections to this feature:
* it increases the complexity of this module with a detail that's specific to Terraform. 
* it potentially opens up a slippery slope towards _more_ complexity, namely parsing more sophisticated `required_version` strings (I don't like to imagine doing that in bash).

On the other hand, I think that this feature is nice. I can think of a few reasons, and others might think of more:
* `required_version` with strict equality seems to be a pretty simple and obvious means of communicating the desired Terraform version.
* `required_version` is supported natively by Terraform itself.

I'm not sure if this has been considered or not yet - I could not find any evidence of discussion using [GitHub's search](https://github.com/asdf-community/asdf-hashicorp/search?q=required_version). Please let me know if I've missed any context around this feature.

I also took the liberty of simplifying some weird shell stuff that I saw going on. It doesn't seem to have broken any tests (although I suppose there were no tests over `parse-legacy-file` in the first place). Please also let me know if I misunderstood the intent behind the argument-related code that I've changed. 

The contents of my commits, including the commit messages, should tell a good story about my changes & motivations, so please read those and not just the overall diff :) Thanks for maintaining this plugin.