### PR TITLE
Check for the existence of required_version

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -23,6 +23,8 @@ read_version_from_main_tf() {
     sed -E 's/[[:space:]]*required_version[[:space:]]*=//' |
     tr -d '" ')"
 
+  [[ -z ${required_version_constraint} ]] && return 0
+
   if is_strict_equality_version_constraint "${required_version_constraint}"; then
     tr -d '=' <<<"${required_version_constraint}"
   else

--- a/test/parse-legacy-file.bats
+++ b/test/parse-legacy-file.bats
@@ -134,3 +134,13 @@ EOF
 
   [[ "${actual_terraform_version}" == "${expected_terraform_version}" ]]
 }
+
+@test "does not output error if required_version is not specified" {
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tf"
+  touch "${version_file}"
+
+  local -r actual_terraform_version="$(ASDF_HASHICORP_THIS_PLUGIN=terraform "${PARSE_LEGACY_FILE}" "${version_file}" 2>&1)"
+
+  [[ "${actual_terraform_version}" == "" ]]
+}


### PR DESCRIPTION
Fixed to check for the existence of `required_version` and suppress the error message.

If required_version is not defined in `main.tf`, the following message is printed.

```
FATAL: Found legacy version file 'main.tf' with unsupported required
version constraint expression: ''. This
plugin only supports strict equality.
```