### PR TITLE
Adds option to look at other Terraform files for version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ install & manage versions.
 - ASDF_HASHICORP_SKIP_VERIFY: skip verifying checksums and signatures
 - ASDF_HASHICORP_OVERWRITE_ARCH: force the plugin to use a specified processor architecture rather than the automatically detected value. Useful, for example, for allowing users on M1 Macs to install `amd64` binaries when there's no `arm64` binary available.
 - ASDF_HASHICORP_OVERWRITE_ARCH_<specific tool>: like the previous override, but for each specific tool, e.g. ASDF_HASHICORP_OVERWRITE_ARCH_TERRAFORM. Works with ASDF_HASHICORP_OVERWRITE_ARCH, and tool-specific overrides take precedence.
+- ASDF_HASHICORP_TERRAFORM_VERSION_FILE: Which `.tf`-file to examine for version constraints when using the `legacy_version_file` option in `~/.asdfrc`. Defaults to `main.tf`
 
 ## License
 

--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo ".terraform-version .packer-version main.tf"
+echo ".terraform-version .packer-version ${ASDF_HASHICORP_TERRAFORM_VERSION_FILE:-main.tf}"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -29,7 +29,7 @@ read_version_from_main_tf() {
     tr -d '=' <<<"${required_version_constraint}"
   else
     cat >&2 <<EOF
-FATAL: Found legacy version file 'main.tf' with unsupported required
+FATAL: Found legacy version file '${ASDF_HASHICORP_TERRAFORM_VERSION_FILE:-main.tf}' with unsupported required
 version constraint expression: '${required_version_constraint}'. This
 plugin only supports strict equality.
 
@@ -54,7 +54,7 @@ get_legacy_version() {
 
   if [[ ${version_file} == *".${THIS_PLUGIN}-version" && -r ${version_file} ]]; then
     cat "${version_file}"
-  elif [[ ${version_file} =~ main.tf && -r ${version_file} ]]; then
+  elif [[ ${version_file} =~ ${ASDF_HASHICORP_TERRAFORM_VERSION_FILE:-main.tf} && -r ${version_file} ]]; then
     read_version_from_main_tf "${version_file}"
   fi
 }

--- a/test/parse-legacy-file.bats
+++ b/test/parse-legacy-file.bats
@@ -20,6 +20,21 @@ EOF
   [[ "${actual_terraform_version}" == "${expected_terraform_version}" ]]
 }
 
+@test "supports alternate file for terraform version constraints" {
+  local -r expected_terraform_version=0.13.7
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/versions.tf"
+  cat <<EOF > "${version_file}"
+terraform {
+  required_version = "= ${expected_terraform_version}"
+}
+EOF
+
+  local -r actual_terraform_version="$(ASDF_HASHICORP_TERRAFORM_VERSION_FILE=versions.tf ASDF_HASHICORP_THIS_PLUGIN=terraform "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ "${actual_terraform_version}" == "${expected_terraform_version}" ]]
+}
+
 @test "supports legacy terraform version 'required_version' with strict equality, no equals literal" {
   local -r expected_terraform_version=0.13.7
   local -r tmpdir="$(mktemp -d)"


### PR DESCRIPTION
We place our `terraform` block (with version constraints) in a file called `versions.tf` which doesn't work, this PR adds another environment variable allowing you to configure alternate filenames which contain the version specification.