### PR TITLE
support terraform 1.2 alpha

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,7 +14,7 @@ list_all() {
   local v
 
   for v in $(curl -s "https://releases.hashicorp.com/${toolname}/" |
-    grep -o "${toolname}_[0-9]\+\.[0-9]\+\.[0-9]\+\(\(-\|+\)[a-z]\+[0-9]*\)*"); do
+    grep -o "${toolname}_[0-9]\+\.[0-9]\+\.[0-9]\+\(\(-\|+\)[a-z]\+-\?[0-9]*\)*"); do
     version="${v#"${toolname}"_}"
     if [[ -z ${versions} ]]; then
       versions="${version}"


### PR DESCRIPTION
Hashicorp changed the naming scheme again for their alphas, adding a
hyphen after the `alpha` part:

	1.2.0-alpha-20220328

Support the new optional `-` in the name.

Fixes #48.