### PR TITLE
Fallback to x86 if missing arm64 version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -18,6 +18,8 @@ toolname="$(basename "$(dirname "${__dirname}")")"
 readonly __dirname
 readonly toolname
 
+SWITCH_ARCH=
+
 # make a temporary download directory with a cleanup hook
 TMP_DOWNLOAD_DIR="$(mktemp -d -t "asdf_${toolname}_XXXXXX")"
 readonly TMP_DOWNLOAD_DIR
@@ -40,7 +42,7 @@ verify() {
   # Returns 1 on GPG signature verification error, 2 on checksum error.
   local -r version="$1"
   local -r platform="$(get_platform)"
-  local -r arch="$(get_arch)"
+  local -r arch="${SWITCH_ARCH:-$(get_arch)}"
   local -r checksum_path="${TMP_DOWNLOAD_DIR}/$(get_checksum_filename "${version}")"
   local -r gpg_path="${TMP_DOWNLOAD_DIR}/$(get_gpg_filename "${version}")"
 
@@ -77,11 +79,13 @@ install() {
   fi
 
   local -r bin_install_path="${install_path}/bin"
-  local -r download_url="$(get_download_url "${version}" "zip")"
-  local -r download_path="${TMP_DOWNLOAD_DIR}/$(get_zip_filename "${version}")"
+  local download_url
+  download_url="$(get_download_url "${version}" "zip")"
+  local download_path
+  download_path="${TMP_DOWNLOAD_DIR}/$(get_zip_filename "${version}")"
 
   echo "Downloading ${toolname} version ${version} from ${download_url}"
-  if curl -fs "${download_url}" -o "${download_path}"; then
+  if download "${download_url}" "${download_path}"; then
     if command -v gpg >/dev/null 2>&1 && [ "${SKIP_VERIFY}" == "false" ]; then
       echo "Verifying signatures and checksums"
       verify "${version}" "${download_path}"
@@ -101,6 +105,27 @@ install() {
     echo "Error: ${toolname} version ${version} not found" >&2
     exit 1
   fi
+}
+
+download() {
+  if curl -fs "${download_url}" -o "${download_path}"; then
+    return 0
+  fi
+
+  if [ "$(get_arch)" != "arm64" ]; then 
+    return 1
+  fi
+
+  SWITCH_ARCH=amd64
+  download_url=${download_url/arm/amd64}
+  download_path=${download_path/arm64/amd64}
+  if [ "$(curl -sIw "%{http_code}"  -o /dev/null "${download_url}")" != "200" ]; then
+    return 1
+  fi
+
+  echo "M1 was detected, but there is no version available. Downloading the amd64 version to run with rosetta!"
+  echo "Downloading ${toolname} version ${version} from ${download_url}"
+  curl -fs "${download_url}" -o "${download_path}"
 }
 
 get_platform() {

--- a/bin/install
+++ b/bin/install
@@ -18,8 +18,6 @@ toolname="$(basename "$(dirname "${__dirname}")")"
 readonly __dirname
 readonly toolname
 
-SWITCH_ARCH=
-
 # make a temporary download directory with a cleanup hook
 TMP_DOWNLOAD_DIR="$(mktemp -d -t "asdf_${toolname}_XXXXXX")"
 readonly TMP_DOWNLOAD_DIR
@@ -42,7 +40,7 @@ verify() {
   # Returns 1 on GPG signature verification error, 2 on checksum error.
   local -r version="$1"
   local -r platform="$(get_platform)"
-  local -r arch="${SWITCH_ARCH:-$(get_arch)}"
+  local -r arch="$(get_arch)"
   local -r checksum_path="${TMP_DOWNLOAD_DIR}/$(get_checksum_filename "${version}")"
   local -r gpg_path="${TMP_DOWNLOAD_DIR}/$(get_gpg_filename "${version}")"
 
@@ -112,18 +110,18 @@ download() {
     return 0
   fi
 
-  if [ "$(get_arch)" != "arm64" ]; then 
+  if [ "$(get_arch)" != "arm64" ] || [ "$(get_platform)" != "darwin" ]; then 
     return 1
   fi
 
-  SWITCH_ARCH=amd64
+  export ASDF_HASHICORP_OVERWRITE_ARCH=amd64
   download_url=${download_url/arm/amd64}
   download_path=${download_path/arm64/amd64}
   if [ "$(curl -sIw "%{http_code}"  -o /dev/null "${download_url}")" != "200" ]; then
     return 1
   fi
 
-  echo "M1 was detected, but there is no version available. Downloading the amd64 version to run with rosetta!"
+  echo "Arm64(M1,*) was detected, but there is no version available. Downloading the amd64 version to run with rosetta!"
   echo "Downloading ${toolname} version ${version} from ${download_url}"
   curl -fs "${download_url}" -o "${download_path}"
 }


### PR DESCRIPTION
We should be ok to run amd64 binaries with rosetta when missing arm64 support, such as old versions of terraform.

```bash
$ asdf install
Downloading terraform version 0.14.11 from https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_darwin_arm.zip
M1 was detected, but there is no version available. Downloading the amd64 version to run with rosetta!
Downloading terraform version 0.14.11 from https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_darwin_amd64.zip
Verifying signatures and checksums
gpg: keybox '/var/folders/14/9h539rxx1zv_j1vv1327d5040000gp/T/asdf_terraform_XXXXXX.vR5YVKOf/pubring.kbx' created
gpg: /var/folders/14/9h539rxx1zv_j1vv1327d5040000gp/T/asdf_terraform_XXXXXX.vR5YVKOf/trustdb.gpg: trustdb created
gpg: key 34365D9472D7468F: public key "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Tue Apr 19 04:34:35 2022 -03
gpg:                using RSA key 374EC75B485913604A831CC7C820C6D5CD27AB87
gpg: Good signature from "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F
     Subkey fingerprint: 374E C75B 4859 1360 4A83  1CC7 C820 C6D5 CD27 AB87
terraform_0.14.11_darwin_amd64.zip: OK
Cleaning terraform previous binaries
Creating terraform bin directory
Extracting terraform archive
```