### PR TITLE
Guide user if error on finding the version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -99,6 +99,7 @@ install() {
     unzip -qq "${download_path}" -d "${bin_install_path}"
   else
     echo "Error: ${toolname} version ${version} not found" >&2
+    echo "Check documentation for alternatives https://github.com/asdf-community/asdf-hashicorp#usage" >&2
     exit 1
   fi
 }


### PR DESCRIPTION
Add a repository link to the error message so the user can follow and better figure out how to workaround. That comes with the confusion on missing darwin arm64 builds for old versions of terraform. There is already a variable to bypass it and run on compatibility mode. Pointing a link can avoid extra support on chats or other channels.

```bash
$ asdf install
Downloading terraform version 0.14.11 from https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_darwin_arm.zip
Error: terraform version 0.14.11 not found
Check documentation for alternatives https://github.com/asdf-community/asdf-hashicorp#usage
```