### PR TITLE
Remove SC2068 exception

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -25,12 +25,7 @@ trap 'rm -rf "${TMP_DOWNLOAD_DIR?}"' EXIT
 
 SKIP_VERIFY=${ASDF_HASHICORP_SKIP_VERIFY:-"false"}
 gnupg() {
-  # This is one of the rare times when we want word splitting, so we can supply
-  # a caller-specified number of arguments to this function to `gpg` as
-  # arguments.
-  #
-  # shellcheck disable=SC2068
-  GNUPGHOME="${TMP_DOWNLOAD_DIR}" gpg $@
+  GNUPGHOME="${TMP_DOWNLOAD_DIR}" gpg "$@"
 }
 
 verify() {


### PR DESCRIPTION
bash handles `"$@"` more intelligently than one might expect. See docs: https://www.shellcheck.net/wiki/SC2068:

> Double quotes around `$@` (and similarly, `${array[@]}`) prevents
> globbing and word splitting of individual elements, while still
> expanding to multiple separate arguments.

Fixes #65