### PR TITLE
feat: releases host URL can be set via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ install & manage versions.
 - ASDF_HASHICORP_OVERWRITE_ARCH: force the plugin to use a specified processor architecture rather than the automatically detected value. Useful, for example, for allowing users on M1 Macs to install `amd64` binaries when there's no `arm64` binary available.
 - ASDF_HASHICORP_OVERWRITE_ARCH_<specific tool>: like the previous override, but for each specific tool, e.g. ASDF_HASHICORP_OVERWRITE_ARCH_TERRAFORM. Works with ASDF_HASHICORP_OVERWRITE_ARCH, and tool-specific overrides take precedence.
 - ASDF_HASHICORP_TERRAFORM_VERSION_FILE: Which `.tf`-file to examine for version constraints when using the `legacy_version_file` option in `~/.asdfrc`. Defaults to `main.tf`
+- ASDF_HASHICORP_RELEASES_HOST: Specify a different host to get the binaries from. (Default is https://releases.hashicorp.com)
 
 ## License
 

--- a/bin/install
+++ b/bin/install
@@ -175,12 +175,13 @@ get_download_url() {
       exit 1
       ;;
   esac
-  local -r releases_host="https://releases.hashicorp.com"
+
+  releases_host=${ASDF_HASHICORP_RELEASES_HOST:-"https://releases.hashicorp.com"}
 
   if ! curl -fs "${releases_host}/${toolname}/${version}/${filename}" >/dev/null && [[ ${filename} == *"arm64"* ]]; then
-    echo "https://releases.hashicorp.com/${toolname}/${version}/${filename//arm64/arm}"
+    echo "${releases_host}/${toolname}/${version}/${filename//arm64/arm}"
   else
-    echo "https://releases.hashicorp.com/${toolname}/${version}/${filename}"
+    echo "${releases_host}/${toolname}/${version}/${filename}"
   fi
 }
 


### PR DESCRIPTION
Add new environment variable ASDF_HASHICORP_RELEASES_HOST to override the default releases host url