### PR TITLE
Avoid downloading release just to check if it exists

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -172,7 +172,7 @@ get_download_url() {
   esac
   local -r releases_host="https://releases.hashicorp.com"
 
-  if ! curl -fs "${releases_host}/${toolname}/${version}/${filename}" >/dev/null && [[ ${filename} == *"arm64"* ]]; then
+  if ! curl -fsI "${releases_host}/${toolname}/${version}/${filename}" >/dev/null && [[ ${filename} == *"arm64"* ]]; then
     echo "https://releases.hashicorp.com/${toolname}/${version}/${filename//arm64/arm}"
   else
     echo "https://releases.hashicorp.com/${toolname}/${version}/${filename}"

--- a/bin/install
+++ b/bin/install
@@ -172,7 +172,7 @@ get_download_url() {
   esac
   local -r releases_host="https://releases.hashicorp.com"
 
-  if ! curl -fsI "${releases_host}/${toolname}/${version}/${filename}" >/dev/null && [[ ${filename} == *"arm64"* ]]; then
+  if ! curl --fail --silent --head "${releases_host}/${toolname}/${version}/${filename}" >/dev/null && [[ ${filename} == *"arm64"* ]]; then
     echo "https://releases.hashicorp.com/${toolname}/${version}/${filename//arm64/arm}"
   else
     echo "https://releases.hashicorp.com/${toolname}/${version}/${filename}"


### PR DESCRIPTION
The `get_download_url` function uses `curl -fs` which will download the file for no reason.
We can take advantage of the headers instead by calling `curl -fsI` which is much faster.