### PR TITLE
Change `plugin-add` to `plugin add` to support asdf 0.16.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@
 ## Installation
 
 ```bash
-asdf plugin-add boundary https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add consul https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add levant https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add nomad https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add packer https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add sentinel https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add serf https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add terraform-ls https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add tfc-agent https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add vault https://github.com/asdf-community/asdf-hashicorp.git
-asdf plugin-add waypoint https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add boundary https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add consul https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add levant https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add nomad https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add packer https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add sentinel https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add serf https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add terraform https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add terraform-ls https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add tfc-agent https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add vault https://github.com/asdf-community/asdf-hashicorp.git
+asdf plugin add waypoint https://github.com/asdf-community/asdf-hashicorp.git
 ```
 
 ## Usage


### PR DESCRIPTION
Updated README to match the new plugin installation method introduced in asdf 0.16.x.